### PR TITLE
fix(ds5): use 4096.0f as SPEC_DELTA_TIME

### DIFF
--- a/virt_ds5.c
+++ b/virt_ds5.c
@@ -19,7 +19,7 @@
 #define DS_OUTPUT_VALID_FLAG2_COMPATIBLE_VIBRATION2 0x04
 #define DS_OUTPUT_VALID_FLAG0_COMPATIBLE_VIBRATION  0x01
 
-#define DS5_SPEC_DELTA_TIME         188.0f
+#define DS5_SPEC_DELTA_TIME         4096.0f
 
 static const char* path = "/dev/uhid";
 


### PR DESCRIPTION
This allows Gyro as X to work with the emulated DualSense Edge controller once again.

This value is incorrect, but it's as close as we can get to the sensor's actual delta time without causing jittering or unusual input.